### PR TITLE
Add fractional second support

### DIFF
--- a/lib/iso8601/duration.rb
+++ b/lib/iso8601/duration.rb
@@ -4,7 +4,7 @@ module ISO8601
   class Duration
     attr_reader :base, :atoms
     def initialize(duration, base = nil)
-      @duration = /^(\+|-)?P(((\d+Y)?(\d+M)?(\d+D)?(T(\d+H)?(\d+M)?(\d+S)?)?)|(\d+W))$/.match(duration)
+      @duration = /^(\+|-)?P(((\d+Y)?(\d+M)?(\d+D)?(T(\d+H)?(\d+M)?(\d+(?:\.\d+)?S)?)?)|(\d+W))$/.match(duration)
       @base = base #date base for duration calculations
       valid_pattern?
       valid_base?

--- a/test/iso8601/test_duration.rb
+++ b/test/iso8601/test_duration.rb
@@ -18,6 +18,7 @@ class TestDuration < Test::Unit::TestCase
     assert_nothing_raised() { ISO8601::Duration.new("PT1H1M") }
     assert_nothing_raised() { ISO8601::Duration.new("PT1H1S") }
     assert_nothing_raised() { ISO8601::Duration.new("PT1H1M1S") }
+    assert_nothing_raised() { ISO8601::Duration.new("P1Y2M3DT5H20M30.123S")}
     assert_nothing_raised() { ISO8601::Duration.new("+PT1H1M1S") }
     assert_nothing_raised() { ISO8601::Duration.new("-PT1H1M1S") }
     assert_raise(ISO8601::Errors::UnknownPattern) { ISO8601::Duration.new("~PT1H1M1S") }


### PR DESCRIPTION
ISO 8601 duration expressions may contain fractional second digits.
