### PR TITLE
ISO8601::Atom#to_i returns an integer

### DIFF
--- a/lib/iso8601/atoms.rb
+++ b/lib/iso8601/atoms.rb
@@ -9,7 +9,7 @@ module ISO8601
     end
 
     def to_i
-      @atom
+      @atom.to_i
     end
     def to_seconds
       @atom * self.factor

--- a/test/iso8601/test_atoms.rb
+++ b/test/iso8601/test_atoms.rb
@@ -12,6 +12,11 @@ class TestAtom < Test::Unit::TestCase
     assert_nothing_raised() { ISO8601::Atom.new(1.1) }
     assert_nothing_raised() { ISO8601::Atom.new(-1.1) }
   end
+  
+  def test_to_i
+    assert_kind_of(Integer, ISO8601::Atom.new(1).to_i)
+    assert_kind_of(Integer, ISO8601::Atom.new(1.0).to_i)
+  end
 end
 class TestYears < Test::Unit::TestCase
   def test_factor


### PR DESCRIPTION
Very simple change. I'm not sure about all the implications and supposed uses of Atom#to_i but I found it surprising that it didn't return, well, an integer.
