### PR TITLE
Resolving issue with ISO8601::Months#factor calculation when the duration is negative.

### DIFF
--- a/lib/iso8601/atoms.rb
+++ b/lib/iso8601/atoms.rb
@@ -85,18 +85,22 @@ module ISO8601
         year = @base.year + ((@base.month) / 12).to_i
         (::Time.utc(year, month) - ::Time.utc(@base.year, @base.month))
       else
-        month = (@base.month + @atom <= 12) ? (@base.month + @atom) : ((@base.month + @atom) % 12)
+        if @base.month + @atom <= 0
+          month = @base.month + @atom
 
-        if month % 12 == 0
-          year = @base.year + (month / 12) - 1
-          month = 12
-        elsif month < 0
-          year = @base.year + (month / 12).floor
-          month = (12 + month > 0) ? (12 + month) : (12 + (month % -12))
+          if month % 12 == 0
+            year = @base.year + (month / 12) - 1
+            month = 12
+          else
+            year = @base.year + (month / 12).floor
+            month = (12 + month > 0) ? (12 + month) : (12 + (month % -12))
+          end
         else
+          month = (@base.month + @atom <= 12) ? (@base.month + @atom) : ((@base.month + @atom) % 12)
+          month = 12 if month == 0
           year = @base.year + ((@base.month + @atom) / 12).to_i
         end
-
+        
         (::Time.utc(year, month) - ::Time.utc(@base.year, @base.month)) / @atom
       end
     end

--- a/spec/iso8601/duration_spec.rb
+++ b/spec/iso8601/duration_spec.rb
@@ -100,6 +100,7 @@ describe ISO8601::Duration do
       it "should return the seconds of a P[n]M duration in a common year" do
         ISO8601::Duration.new('P1M', ISO8601::DateTime.new('2012-01-01')).to_seconds.should == (Time.utc(2012, 2) - Time.utc(2012, 1))
         ISO8601::Duration.new('P2M', ISO8601::DateTime.new('2012-01-01')).to_seconds.should == (Time.utc(2012, 3) - Time.utc(2012, 1))
+        ISO8601::Duration.new('P19M', ISO8601::DateTime.new('2012-05-01')).to_seconds.should == (Time.utc(2014, 12) - Time.utc(2012, 5))
         ISO8601::Duration.new('P14M', ISO8601::DateTime.new('2012-01-01')).to_seconds.should == (Time.utc(2013, 3) - Time.utc(2012, 1))
       end
       it "should return the seconds of a P[n]M duration in a leap year" do


### PR DESCRIPTION
When passing in a negative duration, all atoms correctly calculate their factor except for the Months class.  For instance, if -P3M is the duration with a base date of 2012-1-1, the months is incorrectly calculated as -2 which causes an argument out of range exception from Time#utc.

Also, for positive durations, if the base month plus atom is evenly divisible by 12 but greater than 12, this resulted in a month calculation of 0 which also caused an argument out of range exception.  For instance, if P19M is the duration with a base date of 2012-5-1, the months is incorrectly calculated as 0.
