### PR TITLE
expose hash method

### DIFF
--- a/lib/iso8601/date.rb
+++ b/lib/iso8601/date.rb
@@ -17,7 +17,7 @@ module ISO8601
 
     def_delegators(:@date,
       :to_s, :to_time, :to_date, :to_datetime,
-      :year, :month, :day, :wday)
+      :year, :month, :day, :wday, :hash)
     ##
     # The original atoms
     attr_reader :atoms

--- a/lib/iso8601/dateTime.rb
+++ b/lib/iso8601/dateTime.rb
@@ -12,7 +12,7 @@ module ISO8601
 
     def_delegators(:@date_time,
       :strftime, :to_time, :to_date, :to_datetime,
-      :year, :month, :day, :hour, :minute, :zone)
+      :year, :month, :day, :hour, :minute, :zone, :hash)
 
     attr_reader :second
 

--- a/lib/iso8601/duration.rb
+++ b/lib/iso8601/duration.rb
@@ -148,6 +148,10 @@ module ISO8601
       (self.to_seconds == duration.to_seconds)
     end
 
+    def hash
+      [self.class, iso8601].hash
+    end
+
     private
     ##
     # @param [Numeric] duration The seconds to promote

--- a/lib/iso8601/time.rb
+++ b/lib/iso8601/time.rb
@@ -14,7 +14,7 @@ module ISO8601
 
     def_delegators(:@time,
       :to_time, :to_date, :to_datetime,
-      :hour, :minute, :zone)
+      :hour, :minute, :zone, :hash)
     ##
     # The separator used in the original ISO 8601 string.
     attr_reader :separator


### PR DESCRIPTION
Useful when using:

``` ruby
users.group_by(&:created_at)
```

and the created_at method returns a ISO8601::Time object.
