### PR TITLE
make atoms comparable

### DIFF
--- a/lib/iso8601/atoms.rb
+++ b/lib/iso8601/atoms.rb
@@ -6,6 +6,7 @@ module ISO8601
   #
   # @abstract
   class Atom
+    include Comparable
     ##
     # @param [Numeric] atom The atom value
     # @param [ISO8601::DateTime, nil] base (nil) The base datetime to compute
@@ -55,18 +56,20 @@ module ISO8601
       atom * factor
     end
     ##
-    # @param [#hash] other The contrast to compare against
+    # @param [Atom, #to_f] other The contrast to compare against
     #
-    # @return [Boolean]
-    def ==(other)
-      (hash == other.hash)
+    # @return [-1, 0, 1]
+    def <=>(other)
+      return nil if Atom === other && !other.kind_of?(self.class)
+      return nil unless other.respond_to?(:to_f)
+      to_f <=> other.to_f
     end
     ##
-    # @param [#hash] other The contrast to compare against
+    # @param [Atom, #to_f] other The contrast to compare against
     #
     # @return [Boolean]
     def eql?(other)
-      (hash == other.hash)
+      (self == other)
     end
     ##
     # @return [Fixnum]

--- a/spec/iso8601/atoms_spec.rb
+++ b/spec/iso8601/atoms_spec.rb
@@ -47,6 +47,21 @@ RSpec.describe ISO8601::Atom do
       expect { ISO8601::Atom.new(1).factor }.to raise_error(NotImplementedError)
     end
   end
+  describe '#<=>' do
+    it "should be comparable to atoms of the same type" do
+      expect(ISO8601::Atom.new(1) <=> ISO8601::Atom.new(1)).to eq(0)
+      expect(ISO8601::Atom.new(1) <=> ISO8601::Atom.new(2)).to eq(-1)
+      expect(ISO8601::Atom.new(2) <=> ISO8601::Atom.new(1)).to eq(1)
+    end
+    it "should not be comparable to atoms of a different type" do
+      expect(ISO8601::Years.new(1) <=> ISO8601::Months.new(1)).to be_nil 
+    end
+    it "should be comparable to numerics" do
+      expect(ISO8601::Atom.new(5) <=> 5).to eq(0)
+      expect(ISO8601::Atom.new(5) <=> 1).to eq(1)
+      expect(ISO8601::Atom.new(5) <=> 10).to eq(-1)
+    end
+  end
 end
 
 describe ISO8601::Years do


### PR DESCRIPTION
* atoms are comparable with atoms of the same type
* atoms are comparable with numbers
* atoms are not comparable with atoms of a different type
  because there is no general method to do so