### PR TITLE
Numeric operations with Duration Class

### DIFF
--- a/lib/iso8601/duration.rb
+++ b/lib/iso8601/duration.rb
@@ -341,12 +341,16 @@ module ISO8601
       fail ISO8601::Errors::DurationBaseError, other if base != other.base
     end
 
-    #
+    ##
     # Fetch the number of seconds of another element.
     #
-    # == Parameters:
-    # other::
-    #   ISO8601::Duration instance or Fixnum instance
+    # @param [ISO8601::Duration or Numeric] other Instance of a class to fetch seconds.
+    #
+    # @raise [ISO8601::Errors::DurationBaseError] If bases doesn't match
+    # @raise [ISO8601::Errors::TypeError] If other param is not an instance of
+    #   ISO8601::Duration or Numeric classes
+    #
+    # @return [Float] Number of seconds of other param Object
     #
     def fetch_seconds(other)
       if other.is_a? ISO8601::Duration

--- a/lib/iso8601/duration.rb
+++ b/lib/iso8601/duration.rb
@@ -136,8 +136,7 @@ module ISO8601
     # @raise [ISO8601::Errors::DurationBaseError] If bases doesn't match
     # @return [ISO8601::Duration]
     def +(other)
-      other_seconds = fetch_seconds(other)
-      seconds_to_iso(to_seconds + other_seconds)
+      seconds_to_iso(to_seconds + fetch_seconds(other))
     end
 
     ##
@@ -148,8 +147,7 @@ module ISO8601
     # @raise [ISO8601::Errors::DurationBaseError] If bases doesn't match
     # @return [ISO8601::Duration]
     def -(other)
-      other_seconds = fetch_seconds(other)
-      seconds_to_iso(to_seconds - other_seconds)
+      seconds_to_iso(to_seconds - fetch_seconds(other))
     end
 
     ##
@@ -158,8 +156,7 @@ module ISO8601
     # @raise [ISO8601::Errors::DurationBaseError] If bases doesn't match
     # @return [Boolean]
     def ==(other)
-      other_seconds = fetch_seconds(other)
-      (to_seconds == other_seconds)
+      (to_seconds == fetch_seconds(other))
     end
 
     ##

--- a/lib/iso8601/duration.rb
+++ b/lib/iso8601/duration.rb
@@ -136,8 +136,8 @@ module ISO8601
     # @raise [ISO8601::Errors::DurationBaseError] If bases doesn't match
     # @return [ISO8601::Duration]
     def +(other)
-      compare_bases(other)
-      seconds_to_iso(to_seconds + other.to_seconds)
+      other_seconds = fetch_seconds(other)
+      seconds_to_iso(to_seconds + other_seconds)
     end
 
     ##
@@ -148,8 +148,8 @@ module ISO8601
     # @raise [ISO8601::Errors::DurationBaseError] If bases doesn't match
     # @return [ISO8601::Duration]
     def -(other)
-      compare_bases(other)
-      seconds_to_iso(to_seconds - other.to_seconds)
+      other_seconds = fetch_seconds(other)
+      seconds_to_iso(to_seconds - other_seconds)
     end
 
     ##
@@ -158,8 +158,8 @@ module ISO8601
     # @raise [ISO8601::Errors::DurationBaseError] If bases doesn't match
     # @return [Boolean]
     def ==(other)
-      compare_bases(other)
-      (to_seconds == other.to_seconds)
+      other_seconds = fetch_seconds(other)
+      (to_seconds == other_seconds)
     end
 
     ##
@@ -342,6 +342,24 @@ module ISO8601
 
     def compare_bases(other)
       fail ISO8601::Errors::DurationBaseError, other if base != other.base
+    end
+
+    #
+    # Fetch the number of seconds of another element.
+    #
+    # == Parameters:
+    # other::
+    #   ISO8601::Duration instance or Fixnum instance
+    #
+    def fetch_seconds(other)
+      if other.is_a? ISO8601::Duration
+        compare_bases(other)
+        other.to_seconds
+      elsif other.is_a? Numeric
+        other.to_f
+      else
+        fail ISO8601::Errors::TypeError, other
+      end
     end
   end
 end

--- a/lib/iso8601/errors.rb
+++ b/lib/iso8601/errors.rb
@@ -36,8 +36,5 @@ module ISO8601
         super("Wrong base for #{duration} duration.")
       end
     end
-
-    class TypeError < StandardError
-    end
   end
 end

--- a/spec/iso8601/duration_spec.rb
+++ b/spec/iso8601/duration_spec.rb
@@ -93,6 +93,16 @@ RSpec.describe ISO8601::Duration do
       expect((ISO8601::Duration.new('P1Y1M1DT1H1M1S') + ISO8601::Duration.new('PT10S')).to_s).to eq('P1Y1M1DT1H1M11S')
       expect(ISO8601::Duration.new('P1Y1M1DT1H1M1S') + ISO8601::Duration.new('PT10S')).to be_an_instance_of(ISO8601::Duration)
     end
+
+    it "should perform addition operation with Numeric class" do
+      day = 60 * 60 * 24
+      expect((ISO8601::Duration.new('P11Y1M1DT1H1M1S') + day).to_s).to eq('P11Y1M2DT1H1M1S')
+      expect((ISO8601::Duration.new('P11Y1M1DT1H1M1S') + (2 * day).to_f).to_s).to eq('P11Y1M3DT1H1M1S')
+    end
+
+    it "should raise ISO8601::Errors::TypeError when other object is not Numeric or ISO8601::Duration" do
+      expect { ISO8601::Duration.new('PT1H') + 'wololo' }.to raise_error(ISO8601::Errors::TypeError)
+    end
   end
 
   describe '#-' do
@@ -108,6 +118,13 @@ RSpec.describe ISO8601::Duration do
       expect((ISO8601::Duration.new('PT12S') - ISO8601::Duration.new('PT1S')).to_s).to eq('PT11S')
       expect((ISO8601::Duration.new('PT1S') - ISO8601::Duration.new('PT12S')).to_s).to eq('-PT11S')
       expect((ISO8601::Duration.new('PT1S') - ISO8601::Duration.new('-PT12S')).to_s).to eq('PT13S')
+    end
+
+    it "should perform subtract operation with Numeric class" do
+      day = 60 * 60 * 24
+      minute = 60
+      expect((ISO8601::Duration.new('P11Y1M1DT1H1M1S') - day).to_s).to eq('P11Y1MT1H1M1S')
+      expect((ISO8601::Duration.new('P11Y1M1DT1H1M1S') - (2 * minute).to_f).to_s).to eq('P11Y1M1DT59M1S')
     end
   end
 
@@ -249,6 +266,12 @@ RSpec.describe ISO8601::Duration do
     it "should equal by computed value" do
       expect(ISO8601::Duration.new('PT1H') == ISO8601::Duration.new('PT1H')).to be_truthy
       expect(ISO8601::Duration.new('PT1H') == ISO8601::Duration.new('PT60M')).to be_truthy
+    end
+
+    it "should equal by a Numeric value" do
+      hour = 60 * 60
+      expect(ISO8601::Duration.new('PT1H') == hour).to be_truthy
+      expect(ISO8601::Duration.new('PT2H') == hour).to be_falsy
     end
   end
 


### PR DESCRIPTION
With ISO8601::DateTime class you can do operations like these:

```ruby
hour = 60*60
dt = ISO8601::DateTime.new('2014-05-28T19:53:10Z')
dt + hour
```

When you use this gem with Rails, it's very useful to work with a Numeric class because ActiveSupport provides us with a lot of time helpers: `1.month`, `12.years`...

I add Numeric operations feature to ISO8601::Duration class.