### PR TITLE
Make `Duration#==` nil-safe.

### DIFF
--- a/lib/iso8601/duration.rb
+++ b/lib/iso8601/duration.rb
@@ -123,6 +123,7 @@ module ISO8601
     #
     # @return [Boolean]
     def ==(other)
+      return false if other.nil?
       (to_seconds == fetch_seconds(other))
     end
 


### PR DESCRIPTION
Allow a `ISO8601::Duration` to be compared to `nil` rather than resulting in a `ISO8601::Errors::TypeError`.