### PR TITLE
Fix duration in seconds calculated from november

### DIFF
--- a/lib/iso8601/months.rb
+++ b/lib/iso8601/months.rb
@@ -76,7 +76,7 @@ module ISO8601
       else
         month = initial <= 12 ? initial : (initial % 12)
         month = 12 if month.zero?
-        year = base.year + ((base.month + atom) / 12).to_i
+        year = initial <= 12 ? base.year : base.year + (initial / 12).to_i
       end
 
       (::Time.utc(year, month) - ::Time.utc(base.year, base.month)) / atom

--- a/spec/iso8601/duration_spec.rb
+++ b/spec/iso8601/duration_spec.rb
@@ -7,6 +7,9 @@ RSpec.describe ISO8601::Duration do
   let(:common_february) { ISO8601::DateTime.new('2010-02-01') }
   let(:leap_february) { ISO8601::DateTime.new('2000-02-01') }
 
+  let(:common_november) { ISO8601::DateTime.new('2010-11-01') }
+  let(:common_december) { ISO8601::DateTime.new('2010-12-01') }
+
   it "should raise a ISO8601::Errors::UnknownPattern for any unknown pattern" do
     expect { ISO8601::Duration.new('') }.to raise_error(ISO8601::Errors::UnknownPattern)
     expect { ISO8601::Duration.new('P') }.to raise_error(ISO8601::Errors::UnknownPattern)
@@ -120,6 +123,8 @@ RSpec.describe ISO8601::Duration do
         expect(ISO8601::Duration.new('P1M').to_seconds(common_year)).to eq(2678400)
         expect(ISO8601::Duration.new('P19M').to_seconds(ISO8601::DateTime.new('2012-05-01'))).to eq(Time.utc(2014, 12) - Time.utc(2012, 5))
         expect(ISO8601::Duration.new('P14M').to_seconds(common_year)).to eq(Time.utc(2011, 3) - Time.utc(2010, 1))
+        expect(ISO8601::Duration.new('P1M').to_seconds(common_november)).to eq(Time.utc(2010, 12) - Time.utc(2010, 11))
+        expect(ISO8601::Duration.new('P1M').to_seconds(common_december)).to eq(Time.utc(2011, 1) - Time.utc(2010, 12))
       end
 
       it "should return the seconds of a P[n]M duration in a leap year" do

--- a/spec/iso8601/months_spec.rb
+++ b/spec/iso8601/months_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe ISO8601::Months do
   let(:common_february) { ISO8601::DateTime.new('2010-02-01') }
   let(:leap_february) { ISO8601::DateTime.new('2000-02-01') }
 
+  let(:common_november) { ISO8601::DateTime.new('2017-11-01') }
+
   let(:common_december) { ISO8601::DateTime.new('2017-12-01') }
   let(:leap_december) { ISO8601::DateTime.new('2000-12-01') }
 
@@ -62,6 +64,9 @@ RSpec.describe ISO8601::Months do
       expect(ISO8601::Months.new(1).to_seconds(common_year)).to eq(2678400)
       expect(ISO8601::Months.new(0).to_seconds(common_year)).to eq(0)
       expect(ISO8601::Months.new(0).to_seconds(common_december)).to eq(0)
+      expect(ISO8601::Months.new(2).to_seconds(common_november)).to eq(5270400)
+      expect(ISO8601::Months.new(1).to_seconds(common_november)).to eq(2592000)
+      expect(ISO8601::Months.new(0).to_seconds(common_november)).to eq(0)
     end
 
     it "should return the amount of seconds for a leap year" do


### PR DESCRIPTION
Calculating the number of seconds for 1 month starting from november was incorrect