### PR TITLE
Reduce the number of files that ship in the artifact

### DIFF
--- a/iso8601.gemspec
+++ b/iso8601.gemspec
@@ -17,46 +17,8 @@ Gem::Specification.new do |s|
   DESC
   s.license = 'MIT'
   s.rubyforge_project = 'iso8601'
-  s.files = %w[CHANGELOG.md
-               CONTRIBUTING.md
-               Gemfile
-               LICENSE
-               README.md
-               Rakefile
-               iso8601.gemspec
-               docs/date-time.md
-               docs/duration.md
-               docs/time-interval.md
-               lib/iso8601.rb
-               lib/iso8601/atomic.rb
-               lib/iso8601/date.rb
-               lib/iso8601/date_time.rb
-               lib/iso8601/days.rb
-               lib/iso8601/duration.rb
-               lib/iso8601/errors.rb
-               lib/iso8601/hours.rb
-               lib/iso8601/minutes.rb
-               lib/iso8601/months.rb
-               lib/iso8601/seconds.rb
-               lib/iso8601/time.rb
-               lib/iso8601/time_interval.rb
-               lib/iso8601/version.rb
-               lib/iso8601/weeks.rb
-               lib/iso8601/years.rb
-               spec/iso8601/date_spec.rb
-               spec/iso8601/date_time_spec.rb
-               spec/iso8601/days_spec.rb
-               spec/iso8601/duration_spec.rb
-               spec/iso8601/hours_spec.rb
-               spec/iso8601/minutes_spec.rb
-               spec/iso8601/months_spec.rb
-               spec/iso8601/seconds_spec.rb
-               spec/iso8601/time_interval_spec.rb
-               spec/iso8601/time_spec.rb
-               spec/iso8601/weeks_spec.rb
-               spec/iso8601/years_spec.rb
-               spec/spec_helper.rb]
-  s.test_files = s.files.grep(%r{^spec/})
+  s.files =  %w{LICENSE README.md CONTRIBUTING.md} + `git ls-files`.split("\n").select { |f| f =~ %r{^(?:lib/)}i }
+  s.test_files = %w{Rakefile iso8601.gemspec Gemfile} + `git ls-files`.split("\n").select { |f| f =~ %r{^(?:specs/)}i }
   s.require_paths = ['lib']
 
   s.has_rdoc = 'yard'


### PR DESCRIPTION
The installed artifact for this gem is rather large. Since the install
is really just an artifact buried deep on a user's system there's no
need to ship the full test suite and documentation. This reduces the
install size, especially for packages products that use this gem. It's a
pretty common pattern to only ship the lib dir to keep the install size
down.

Signed-off-by: Tim Smith <tsmith@chef.io>