### PR TITLE
Rework #to_s to eliminate Ruby warning

### DIFF
--- a/lib/iso8601/date_time.rb
+++ b/lib/iso8601/date_time.rb
@@ -47,9 +47,9 @@ module ISO8601
     ##
     # Converts DateTime to a formated string
     def to_s
-      second_format = format((second % 1).zero? ? '%02d' : '%04.1f', second)
+      second_format = (second % 1).zero? ? '%02d' : '%04.1f'
 
-      format("%04d-%02d-%02dT%02d:%02d:#{second_format}#{zone}", *atoms)
+      format("%04d-%02d-%02dT%02d:%02d:#{second_format}%s", *atoms)
     end
 
     ##


### PR DESCRIPTION
Using the ISO8601::DateTime#to_s with warnings enabled produced
the following warning:

`iso8601-0.12.1/lib/iso8601/date_time.rb:52: warning: too many arguments for format string`

This is because the #atoms method is returning an array of 7
elements, which turns into 7 arguments for the `format` method.
The current format passed only uses 5 arguments. This change
adjusts the format passed to use all 7 arguments.