### PR TITLE
Drop `git ls-files` in gemspec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,6 @@
+require:
+  - rubocop-packaging
+
 AllCops:
   Exclude:
     - bundle/vendors/**/*

--- a/iso8601.gemspec
+++ b/iso8601.gemspec
@@ -16,14 +16,15 @@ Gem::Specification.new do |s|
     and times) standard.
   DESC
   s.license = 'MIT'
-  s.files =  %w{LICENSE README.md CONTRIBUTING.md} + `git ls-files`.split("\n").select { |f| f =~ %r{^(?:lib/)}i }
-  s.test_files = %w{iso8601.gemspec Gemfile} + `git ls-files`.split("\n").select { |f| f =~ %r{^(?:specs/)}i }
+  s.files = Dir['{docs,lib}/**/*', 'LICENSE', 'README.md']
+  s.test_files = Dir['spec/**/*']
   s.require_paths = ['lib']
 
   s.metadata["yard.run"] = "yri"
   s.required_ruby_version = '>= 2.0.0'
   s.add_development_dependency 'rspec', '~> 3.9'
   s.add_development_dependency 'rubocop', '~> 0.85'
+  s.add_development_dependency 'rubocop-packaging', '~> 0.1.1'
   s.add_development_dependency 'pry', '~> 0.13.1'
   s.add_development_dependency 'pry-doc', '~> 1.1.0'
 end


### PR DESCRIPTION
Hi @arnau,

Thanks for working on this! :heart: 
However, while maintaining this in Debian, we found that this library relies on `git` to list the files which could be done via pure Ruby alternative -- which is what this PR does.

As an addition, this PR makes sure that this gem only ships the required files to the end users and not other things which are not needed by them! :rocket: 

Also, added rubocop-packaging as a development_dependency which will ensure the best practices.
Here's what it shows us:

```
➜  ISO8601 git:(master)  rubocop --only Packaging

Offenses:

iso8601.gemspec:19:54: C: Packaging/GemspecGit: Avoid using git to produce lists of files. Downstreams
often need to build your package in an environment that does not have git (on purpose). Use some pure
Ruby alternative, like Dir or Dir.glob.
  s.files =  %w{LICENSE README.md CONTRIBUTING.md} + `git ls-files`.split("\n").select { |f| f =~ %r{^(?:lib/)}i }
                                                     ^^^^^^^^^^^^^^

31 files inspected, 1 offense detected
```

And this PR fixes the same, which helps us in shipping this in Debian! :tada: 
Hope this would make sense and you'll be open to this change :100: 

Signed-off-by: Utkarsh Gupta <<utkarsh@debian.org>>